### PR TITLE
Swift 3 Migration

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,22 +1,34 @@
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '8.0'
+platform :ios, '9.0'
 use_frameworks!
 
+def swinject_pods
+    pod 'Swinject', '2.0.0-beta.2'
+    pod 'SwinjectStoryboard', '1.0.0-beta.2'
+end
+
 target :SwinjectSimpleExample do
-  pod 'Alamofire', '~> 3.1.0'
-  pod 'SwiftyJSON', '~> 2.3.0'
-  pod 'Swinject', '0.5'
+  pod 'Alamofire', '~> 4.0'
+  pod 'SwiftyJSON', '~> 3.1'
+  swinject_pods
 end
 
 def testing_pods
-    pod 'Quick', '0.8.0'
-    pod 'Nimble', '3.0.0'
+    pod 'Quick', '0.10'
+    pod 'Nimble', '5.0'
+    swinject_pods
 end
 
 target 'SwinjectSimpleExampleTests' do
     testing_pods
 end
 
-#target 'SwinjectSimpleExampleUITests' do
-#    testing_pods
-#end
+post_install do |installer|
+    installer.pods_project.targets.each do |target|
+        target.build_configurations.each do |config|
+            # https://github.com/CocoaPods/CocoaPods/issues/5521
+            # Now that we've updated to Swift 3, ensure that CocoaPods specify the correct version setting for all targets
+            config.build_settings['SWIFT_VERSION'] = '3.0'
+        end
+    end
+end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,24 +1,28 @@
 PODS:
-  - Alamofire (3.1.2)
-  - Nimble (3.0.0)
-  - Quick (0.8.0)
-  - SwiftyJSON (2.3.0)
-  - Swinject (0.5)
+  - Alamofire (4.0.1)
+  - Nimble (5.0.0)
+  - Quick (0.10.0)
+  - SwiftyJSON (3.1.1)
+  - Swinject (2.0.0-beta.2)
+  - SwinjectStoryboard (1.0.0-beta.2):
+    - Swinject (= 2.0.0-beta.2)
 
 DEPENDENCIES:
-  - Alamofire (~> 3.1.0)
-  - Nimble (= 3.0.0)
-  - Quick (= 0.8.0)
-  - SwiftyJSON (~> 2.3.0)
-  - Swinject (= 0.5)
+  - Alamofire (~> 4.0)
+  - Nimble (= 5.0)
+  - Quick (= 0.10)
+  - SwiftyJSON (~> 3.1)
+  - Swinject (= 2.0.0-beta.2)
+  - SwinjectStoryboard (= 1.0.0-beta.2)
 
 SPEC CHECKSUMS:
-  Alamofire: 7c16ca65f3c7e681fd925fd7f2dec7747ff96855
-  Nimble: 4c353d43735b38b545cbb4cb91504588eb5de926
-  Quick: 563d0f6ec5f72e394645adb377708639b7dd38ab
-  SwiftyJSON: 8d6b61a70277ef2a5d710d372e06e7e2d87fb9e4
-  Swinject: 0bf92c3336808a69d162bcf8f338774640de518a
+  Alamofire: 7682d43245de14874acd142ec137b144aa1dd335
+  Nimble: 56fc9f5020effa2206de22c3dd910f4fb011b92f
+  Quick: 5d290df1c69d5ee2f0729956dcf0fd9a30447eaa
+  SwiftyJSON: f0be2e604f83e8405a624e9f891898bf6ed4e019
+  Swinject: 69a893192efa9f2cc44be79ef423d04d571b6af9
+  SwinjectStoryboard: b52b45821a50386ef604c3cd098f8029a50a268d
 
-PODFILE CHECKSUM: 9df9ec5a8f8f2dbfc93d9bc8d6377d834fd385d8
+PODFILE CHECKSUM: 10288fb3b26677fe16a777a1c9fad530301d305d
 
-COCOAPODS: 1.0.1
+COCOAPODS: 1.1.1

--- a/SwinjectSimpleExample.xcodeproj/project.pbxproj
+++ b/SwinjectSimpleExample.xcodeproj/project.pbxproj
@@ -222,9 +222,11 @@
 				TargetAttributes = {
 					98BA272F1B785EB00047549E = {
 						CreatedOnToolsVersion = 7.0;
+						LastSwiftMigration = 0810;
 					};
 					98BA27431B785EB00047549E = {
 						CreatedOnToolsVersion = 7.0;
+						LastSwiftMigration = 0810;
 						TestTargetID = 98BA272F1B785EB00047549E;
 					};
 				};
@@ -341,7 +343,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		A6088DC68474DB0398F634D5 /* [CP] Check Pods Manifest.lock */ = {
@@ -356,7 +358,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -506,6 +508,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.el-eleven.SwinjectSimpleExample";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -518,6 +521,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.el-eleven.SwinjectSimpleExample";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -530,6 +534,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.el-eleven.SwinjectSimpleExampleTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SwinjectSimpleExample.app/SwinjectSimpleExample";
 			};
 			name = Debug;
@@ -543,6 +548,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.el-eleven.SwinjectSimpleExampleTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SwinjectSimpleExample.app/SwinjectSimpleExample";
 			};
 			name = Release;

--- a/SwinjectSimpleExample/AppDelegate.swift
+++ b/SwinjectSimpleExample/AppDelegate.swift
@@ -12,30 +12,30 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }
 
-    func applicationWillResignActive(application: UIApplication) {
+    func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
     }
 
-    func applicationDidEnterBackground(application: UIApplication) {
+    func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
 
-    func applicationWillEnterForeground(application: UIApplication) {
+    func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
     }
 
-    func applicationDidBecomeActive(application: UIApplication) {
+    func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
 
-    func applicationWillTerminate(application: UIApplication) {
+    func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 }

--- a/SwinjectSimpleExample/Network.swift
+++ b/SwinjectSimpleExample/Network.swift
@@ -10,10 +10,9 @@ import Foundation
 import Alamofire
 
 struct Network : Networking {
-    func request(response: NSData? -> ()) {
-        Alamofire.request(.GET, OpenWeatherMap.url, parameters: OpenWeatherMap.parameters)
-            .response { _, _, data, _ in
-                response(data)
-            }
+    func request(_ networkResponse: @escaping (Data?) -> ()) {
+        Alamofire.request(OpenWeatherMap.url, parameters: OpenWeatherMap.parameters).responseData { (dataResponse) in
+            networkResponse(dataResponse.data)
+        }
     }
 }

--- a/SwinjectSimpleExample/Networking.swift
+++ b/SwinjectSimpleExample/Networking.swift
@@ -9,5 +9,5 @@
 import Foundation
 
 protocol Networking {
-    func request(response: NSData? -> ())
+    func request(_ response: @escaping (Data?) -> ())
 }

--- a/SwinjectSimpleExample/OpenWeatherMap.swift
+++ b/SwinjectSimpleExample/OpenWeatherMap.swift
@@ -11,7 +11,7 @@ struct OpenWeatherMap {
     // The key is available for free.
     // http://openweathermap.org
     private static let apiKey = ""
-    
+
     private static let cityIds = [
         6077243, 524901, 5368361, 1835848, 3128760, 4180439,
         2147714, 264371, 1816670, 2643743, 3451190, 1850147
@@ -22,7 +22,7 @@ struct OpenWeatherMap {
     static var parameters: [String: String] {
         return [
             "APPID": apiKey,
-            "id": cityIds.map { String($0) }.joinWithSeparator(",")
+            "id": cityIds.map { String($0) }.joined(separator: ",")
         ]
     }
 }

--- a/SwinjectSimpleExample/SwinjectStoryboard+Setup.swift
+++ b/SwinjectSimpleExample/SwinjectStoryboard+Setup.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Swinject Contributors. All rights reserved.
 //
 
-import Swinject
+import SwinjectStoryboard
 
 extension SwinjectStoryboard {
     class func setup() {

--- a/SwinjectSimpleExample/WeatherFetcher.swift
+++ b/SwinjectSimpleExample/WeatherFetcher.swift
@@ -13,14 +13,14 @@ import SwiftyJSON
 struct WeatherFetcher {
     let networking: Networking
     
-    func fetch(response: [City]? -> ()) {
+    func fetch(_ response: @escaping ([City]?) -> ()) {
         networking.request { data in
-            let cities = data.map { self.decode($0) }
+            let cities = data.map { self.decode($0 as Data) }
             response(cities)
         }
     }
     
-    private func decode(data: NSData) -> [City] {
+    fileprivate func decode(_ data: Data) -> [City] {
         let json = JSON(data: data)
         var cities = [City]()
         for (_, j) in json["list"] {

--- a/SwinjectSimpleExample/WeatherTableViewController.swift
+++ b/SwinjectSimpleExample/WeatherTableViewController.swift
@@ -10,13 +10,13 @@ import UIKit
 
 class WeatherTableViewController: UITableViewController {
     var weatherFetcher: WeatherFetcher?
-    private var cities = [City]() {
+    fileprivate var cities = [City]() {
         didSet {
             tableView.reloadData()
         }
     }
     
-    override func viewWillAppear(animated: Bool) {
+    override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
         weatherFetcher?.fetch {
@@ -27,22 +27,22 @@ class WeatherTableViewController: UITableViewController {
                 let title = "Error"
                 let message = "Cannot communicate with the weather server. Check wi-fi or cellular network settings."
                 let dismiss = "Dismiss"
-                let alert = UIAlertController(title: title, message: message, preferredStyle: .Alert)
-                alert.addAction(UIAlertAction(title: dismiss, style: .Default) { _ in
-                    alert.dismissViewControllerAnimated(true, completion: nil)
+                let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: dismiss, style: .default) { _ in
+                    alert.dismiss(animated: true, completion: nil)
                 })
-                self.presentViewController(alert, animated: true, completion: nil)
+                self.present(alert, animated: true, completion: nil)
             }
         }
     }
     
     // MARK: UITableViewDataSource
-    override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return cities.count
     }
     
-    override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCellWithIdentifier("Cell", forIndexPath: indexPath)
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
         let city = cities[indexPath.row]
         cell.textLabel?.text = city.name
         cell.detailTextLabel?.text = city.weather

--- a/SwinjectSimpleExampleTests/WeatherFetcherSpec.swift
+++ b/SwinjectSimpleExampleTests/WeatherFetcherSpec.swift
@@ -14,7 +14,7 @@ import Swinject
 
 class WeatherFetcherSpec: QuickSpec {
     struct StubNetwork: Networking {    
-        private static let json =
+        fileprivate static let json =
         "{" +
             "\"list\": [" +
                 "{" +
@@ -38,8 +38,8 @@ class WeatherFetcherSpec: QuickSpec {
             "]" +
         "}"
         
-        func request(response: NSData? -> ()) {
-            let data = StubNetwork.json.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)
+        func request(_ response: @escaping (Data?) -> ()) {
+            let data = StubNetwork.json.data(using: String.Encoding.utf8, allowLossyConversion: false)
             response(data)
         }
     }

--- a/SwinjectSimpleExampleTests/WeatherTableViewControllerSpec.swift
+++ b/SwinjectSimpleExampleTests/WeatherTableViewControllerSpec.swift
@@ -15,8 +15,8 @@ class WeatherTableViewControllerSpec: QuickSpec {
     class MockNetwork: Networking {
         var requestCount = 0
         
-        func request(response: NSData? -> ()) {
-            requestCount++
+        func request(_ response: @escaping (Data?) -> ()) {
+            requestCount += 1
         }
     }
     
@@ -25,7 +25,7 @@ class WeatherTableViewControllerSpec: QuickSpec {
         beforeEach {
             container = Container()
             container.register(Networking.self) { _ in MockNetwork() }
-                .inObjectScope(.Container)
+                .inObjectScope(.container)
             container.register(WeatherFetcher.self) { r in
                 WeatherFetcher(networking: r.resolve(Networking.self)!)
             }


### PR DESCRIPTION
Fixes #3 

Notes:
* Alamofire 4 has a minimum iOS version of 9.0, so ours had to be updated
* Swinject pods needed to be added to test target, I was seeing linking errors
* post_install hook to set `SWIFT_VERSION` 2.3 for all pods